### PR TITLE
Move grunt to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/BankFacil/vanilla-masker/issues"
   },
   "homepage": "http://bankfacil.github.io/vanilla-masker",
-  "dependencies": {
+  "devDependencies": {
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-connect": "^0.7.1",
     "grunt-contrib-uglify": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seatgeek-vanilla-masker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "VanillaMasker is a pure javascript input mask.",
   "main": "lib/vanilla-masker.js",
   "scripts": {


### PR DESCRIPTION
Right now it's installing all grunt packages, one includes phantomjs which takes a considerable amount of time.
